### PR TITLE
feat: AI Kernel Connectivity

### DIFF
--- a/src/main/java/io/trishul/flux/chakra/cognitive/OllamaClient.java
+++ b/src/main/java/io/trishul/flux/chakra/cognitive/OllamaClient.java
@@ -1,0 +1,51 @@
+package io.trishul.flux.chakra.cognitive;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.http.MediaType;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+public class OllamaClient {
+
+    private final RestClient restClient;
+    private static final String OLLAMA_URL = "http://localhost:11434/api/generate";
+
+    public OllamaClient() {
+        this.restClient = RestClient.create();
+    }
+
+    /**
+     * Sends a prompt to the local 0.5B model.
+     * using stream: false to get a single consolidated response.
+     */
+    public String chat(String prompt) {
+        try {
+            Map<String, Object> body = Map.of(
+                    "model", "qwen2.5-coder:0.5b",
+                    "prompt", prompt,
+                    "stream", false
+            );
+
+            log.info("Chakra: Sending request to 0.5B model...");
+
+            OllamaResponse response = restClient.post()
+                    .uri(OLLAMA_URL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(body)
+                    .retrieve()
+                    .body(OllamaResponse.class);
+
+            return (response != null) ? response.response() : "No response from AI";
+        } catch (Exception e) {
+            log.error("Chakra: AI Connection failed. Ensure Ollama is running. Error: {}", e.getMessage());
+            return "AI_OFFLINE";
+        }
+    }
+
+    // Simple record to map Ollama's response JSON
+    private record OllamaResponse(String response) {}
+}

--- a/src/test/java/io/trishul/flux/chakra/cognitive/AiConnectivityTest.java
+++ b/src/test/java/io/trishul/flux/chakra/cognitive/AiConnectivityTest.java
@@ -1,0 +1,26 @@
+package io.trishul.flux.chakra.cognitive;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class AiConnectivityTest {
+
+    @Autowired
+    private OllamaClient ollamaClient;
+
+    @Test
+    void verifyAiConnection() {
+        String testPrompt = "Respond with the word 'READY' only.";
+        String response = ollamaClient.chat(testPrompt);
+
+        System.out.println("AI Response: " + response);
+
+        assertNotNull(response);
+        assertNotEquals("AI_OFFLINE", response);
+        assertTrue(response.toUpperCase().contains("READY"));
+    }
+}


### PR DESCRIPTION
## Overview
This PR initializes the 'Cognition' layer. 
We now have the ability to send system context to a local LLM for reasoning.

## Changes
- Created `OllamaClient.java` using memory-efficient RestClient.
- Added a simple JSON mapping for Ollama's response format.
- Validated connection with a specialized 'READY' test.