### PR TITLE
feat: implement FluxCircuitBreaker for fault isolation

### DIFF
--- a/src/main/java/io/trishul/flux/core/execution/FluxCircuitBreaker.java
+++ b/src/main/java/io/trishul/flux/core/execution/FluxCircuitBreaker.java
@@ -1,0 +1,49 @@
+package io.trishul.flux.core.execution;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Slf4j
+@Component
+public class FluxCircuitBreaker {
+
+    public enum State { CLOSED, OPEN, HALF_OPEN }
+
+    private State state = State.CLOSED;
+    private final AtomicInteger failureCount = new AtomicInteger(0);
+    private final int failureThreshold = 3;
+    private long lastTripTimestamp = 0;
+    private final long recoveryTimeout = 5000; // 5 seconds
+
+    public boolean canExecute() {
+        if (state == State.OPEN) {
+            if (System.currentTimeMillis() - lastTripTimestamp > recoveryTimeout) {
+                state = State.HALF_OPEN;
+                log.info("CircuitBreaker: Attempting recovery (HALF_OPEN)");
+                return true;
+            }
+            return false;
+        }
+        return true;
+    }
+
+    public void recordSuccess() {
+        failureCount.set(0);
+        if (state == State.HALF_OPEN) {
+            state = State.CLOSED;
+            log.info("CircuitBreaker: System recovered (CLOSED)");
+        }
+    }
+
+    public void recordFailure() {
+        int failures = failureCount.incrementAndGet();
+        if (failures >= failureThreshold && state != State.OPEN) {
+            state = State.OPEN;
+            lastTripTimestamp = System.currentTimeMillis();
+            log.error("CircuitBreaker: Failure threshold reached. Circuit is now OPEN!");
+        }
+    }
+
+    public State getState() { return state; }
+}

--- a/src/test/java/io/trishul/flux/core/execution/CircuitBreakerTest.java
+++ b/src/test/java/io/trishul/flux/core/execution/CircuitBreakerTest.java
@@ -1,0 +1,24 @@
+package io.trishul.flux.core.execution;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class CircuitBreakerTest {
+
+    @Test
+    void verifyStateTransitions() {
+        FluxCircuitBreaker cb = new FluxCircuitBreaker();
+
+        // Trigger failures
+        cb.recordFailure();
+        cb.recordFailure();
+        cb.recordFailure();
+
+        assertEquals(FluxCircuitBreaker.State.OPEN, cb.getState());
+        assertFalse(cb.canExecute(), "Should block execution when OPEN");
+
+        // Success after failure shouldn't work while OPEN (must wait for timeout)
+        cb.recordSuccess();
+        assertEquals(FluxCircuitBreaker.State.OPEN, cb.getState());
+    }
+}


### PR DESCRIPTION
Implemented the second prong of the Trishul (The Preserver).
- Created FluxCircuitBreaker to handle internal service failures.
- Implemented state transition logic (CLOSED -> OPEN -> HALF_OPEN).
- Added 5-second recovery timeout for self-healing attempts.
- Verified state transitions and execution blocking via CircuitBreakerTest.